### PR TITLE
fix numpy import error

### DIFF
--- a/environment_munge.yml
+++ b/environment_munge.yml
@@ -1,5 +1,6 @@
 name: ldsc_munge
 channels:
+  - defaults
   - bioconda
 dependencies:
   - python=2.7


### PR DESCRIPTION
numpy import error resulted from installing packages via `conda-forge` channel. specify conda `defaults` channel in this yml to prevent that happening in case user conda is configured to search `conda-forge` first